### PR TITLE
fixed mLockCount member parameter not initialized.

### DIFF
--- a/SchaeferGL-Library/CVertexBuffer9.cpp
+++ b/SchaeferGL-Library/CVertexBuffer9.cpp
@@ -36,6 +36,7 @@ CVertexBuffer9::CVertexBuffer9(CDevice9* device, UINT Length, DWORD Usage, DWORD
 	mSize(0),
 	mCapacity(0),
 	mIsDirty(true),
+	mLockCount(0),
 	mBuffer(VK_NULL_HANDLE),
 	mMemory(VK_NULL_HANDLE)
 {

--- a/SchaeferGL-Library/CVertexBuffer9.h
+++ b/SchaeferGL-Library/CVertexBuffer9.h
@@ -55,7 +55,7 @@ public:
 public:
 	//IUnknown
 	virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid,void  **ppv);
-	virtual ULONG STDMETHODCALLTYPE AddRef(void);	
+	virtual ULONG STDMETHODCALLTYPE AddRef(void);
 	virtual ULONG STDMETHODCALLTYPE Release(void);
 
 	//IDirect3DResource9


### PR DESCRIPTION
Although the lock count member variable is not used atm we
should initialize it.